### PR TITLE
[RAI-19751] Use all 32 cores for default size, and add the required interactive threads

### DIFF
--- a/rai_service_spec.yaml
+++ b/rai_service_spec.yaml
@@ -46,7 +46,7 @@ spec:
       ]
     env:
       SERVER_PORT: 8010
-      JULIA_NUM_THREADS: 5
+      JULIA_NUM_THREADS: 32,2
       CONSUL_ADDRESS: http://rai-service:8500
     volumeMounts:
       - name: shared-stage


### PR DESCRIPTION
fixes https://relationalai.atlassian.net/browse/RAI-19751.

Without the interactive threads, the engine will become nonresponsive under load, and stop emitting metrics and accepting new requests. (This is quite possibly why their engine stops replying to 1+1 while it's busy.)

@maxdemarzi: If they're planning to run on an even larger machine tomorrow, they'll need to set this to match their core-count. Is there some way we can make this dependent on the machine in any way? Or should they just remember to change it?